### PR TITLE
ci: generalize publishing and group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,24 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+      day: monday
+      time: "06:00"
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 2
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+      day: monday
+      time: "06:00"
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 2
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: medtrack-project/medtrack-ai
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   verify:


### PR DESCRIPTION
## Contexto

Esta tarefa visa ajustar os scripts da pasta `.github/workflows/` para utilizarem referências dinâmicas de repositório `${{ github.repository }}`, eliminando falhas de permissão ao publicar imagens em forks e mantendo a compatibilidade com o repositório upstream da organização. 

Adicionalmente, o arquivo `.github/dependabot.yml` será refatorado com o uso de grupos (groups), unificando as atualizações de dependências (pip e GitHub Actions) em lotes semanais únicos para evitar poluição visual no grafo de commits e na aba de Pull Requests.

Closes #36 

## Alterações

- Removeu o hardcode em `.github/workflows/release-image.yml` que impedia o funcionamento da esteira de CI/CD dos forks
- Atualização do Dependabot para agrupar as PR's

## Validação

- [x] Testes relevantes executados localmente.
- [x] Lint e checagem de tipos executados, quando aplicável.
- [x] Documentação, configuração e variáveis de ambiente atualizadas, quando aplicável.
- [x] Não foram incluídos segredos, dados de treinamento ou artefatos de modelo.

## Impacto operacional

- CI/CD